### PR TITLE
add greasemonkey script that prevents left/arrow keys from going to

### DIFF
--- a/NYTimes Disable Left-Right Arrow Key Article Switching.user.js
+++ b/NYTimes Disable Left-Right Arrow Key Article Switching.user.js
@@ -1,0 +1,21 @@
+// ==UserScript==
+// @name         test
+// @namespace    sarahgerweck
+// @version      0.1
+// @description  Prevents left/right arrow keys going to prev/next article.
+// @author       You
+// @match        http*://*.nytimes.com/*
+// @require      https://code.jquery.com/jquery-1.11.3.min.js
+// @grant        none
+// ==/UserScript==
+
+// tampermonkey
+
+$(document).ready(function() {
+    $("body").keydown(function(e) {
+        if (e.keyCode == 37 || e.keyCode == 39) {
+            e.preventDefault();
+            return false;
+        }
+    });
+});

--- a/NYTimes Disable Left-Right Arrow Key Article Switching.user.js
+++ b/NYTimes Disable Left-Right Arrow Key Article Switching.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name         test
+// @name         NYTimes Disable Left-Right Arrow Key Article Switching
 // @namespace    sarahgerweck
 // @version      0.1
 // @description  Prevents left/right arrow keys going to prev/next article.

--- a/NYTimes_Disable_LeftRight_Arrow_Key_Article_Switching.user.js
+++ b/NYTimes_Disable_LeftRight_Arrow_Key_Article_Switching.user.js
@@ -8,6 +8,8 @@
 // @grant       none
 // ==/UserScript==
 
+// greasemonkey
+
 var $ = unsafeWindow.jQuery;
 $(document).ready(function() {
   $("body").keydown(function(e) { 

--- a/NYTimes_Disable_LeftRight_Arrow_Key_Article_Switching.user.js
+++ b/NYTimes_Disable_LeftRight_Arrow_Key_Article_Switching.user.js
@@ -2,7 +2,7 @@
 // @name        NYTimes Disable Left/Right Arrow Key Article Switching
 // @namespace   sarahgerweck
 // @description Prevents left/right arrow keys going to prev/next article.
-// @include     http://*.nytimes.com*
+// @include     http*://*.nytimes.com*
 // @require     https://code.jquery.com/jquery-1.11.3.min.js
 // @version     1
 // @grant       none

--- a/NYTimes_Disable_LeftRight_Arrow_Key_Article_Switching.user.js
+++ b/NYTimes_Disable_LeftRight_Arrow_Key_Article_Switching.user.js
@@ -1,0 +1,19 @@
+// ==UserScript==
+// @name        NYTimes Disable Left/Right Arrow Key Article Switching
+// @namespace   sarahgerweck
+// @description Prevents left/right arrow keys going to prev/next article.
+// @include     http://*.nytimes.com*
+// @require     https://code.jquery.com/jquery-1.11.3.min.js
+// @version     1
+// @grant       none
+// ==/UserScript==
+
+var $ = unsafeWindow.jQuery;
+$(document).ready(function() {
+  $("body").keydown(function(e) { 
+    if (e.keyCode == 37 || e.keyCode == 39) {
+      e.preventDefault();
+      return false;
+    }
+  });
+});


### PR DESCRIPTION
next/prev article on nytimes

(btw: You can view as many nytimes articles as you want without a subscription in a private window in firefox, or in incognito mode in chrome.)
